### PR TITLE
 Add option to use the default media folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # PlexGuide-PGClone
+
+Modified to choose if you want the default folders created or not

--- a/gcrypt.yml
+++ b/gcrypt.yml
@@ -9,6 +9,10 @@
 - hosts: localhost
   gather_facts: false
   tasks:
+    - name: Read Default Folder Choice
+      shell: "cat /var/plexguide/pgclone.defaultFolders"
+      register: defaultFolderChoice
+    
     - name: Install GCrypt Service
       template:
         src: /opt/pgclone/templates/gcrypt.service
@@ -22,10 +26,15 @@
         state: reloaded
         name: gcrypt
 
-    - name: Create GCrypt Folders
+    - name: Create GCrypt Folder
       file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
       with_items:
         - /mnt/gcrypt
+        
+    - name: Create GCrypt Default Folders
+      when: defaultFolderChoice.stdout.find('Yes') != -1
+      file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
+      with_items:
         - /mnt/gcrypt/tv
         - /mnt/gcrypt/movies
         - /mnt/gcrypt/music

--- a/gdrive.sh
+++ b/gdrive.sh
@@ -44,7 +44,15 @@ tee <<-EOF
 Choosing yes will make the folders: tv, movies, music, ebooks, abooks
 in the root of your google drive/team drive!
 
-If you don't know what you're doing, or it's a new setup then leave as yes!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚠️  System Message: Warning!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+This is for advanced users ONLY. 
+If you don't know what you're doing, leave it as YES!
+No help will be provided if this is set to NO!
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 [1] Yes, use default folders
 [2] No, don't use default folders (ADVANCED!)

--- a/gdrive.sh
+++ b/gdrive.sh
@@ -35,6 +35,47 @@ core () {
     fi
 }
 
+createDefaultFolders() {
+tee <<-EOF
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🚀 Create Default Folders?            📓 Reference: defaultFolders.plexguide.com
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Choosing yes will make the folders: tv, movies, music, ebooks, abooks
+in the root of your google drive/team drive!
+
+If you don't know what you're doing, or it's a new setup then leave as yes!
+
+[1] Yes, use default folders
+[2] No, don't use default folders (ADVANCED!)
+[Z] Exit
+
+EOF
+read -p '↘️  Type Selection | Press [ENTER]: ' typed < /dev/tty
+
+  if [ "$typed" == "1" ]; then
+      echo "Yes" > /var/plexguide/pgclone.defaultFolders
+  elif [ "$typed" == "2" ]; then
+    echo "No" > /var/plexguide/pgclone.defaultFolders
+  elif [[ "$typed" == "Z" || "$typed" == "z" ]]; then
+   exit
+  else
+    badinput
+    createDefaultFolders
+    exit
+  fi
+    
+    
+tee <<-EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🌎 Default Folders Set                📓 Reference: defaultFolders.plexguide.com
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EOF
+read -p '↘️  Acknowledge Info  | Press [ENTER] ' public < /dev/tty
+
+}
+
 rcloneprime () {
   curl https://rclone.org/install.sh | sudo bash -s beta
   rcpiece
@@ -62,6 +103,7 @@ fi
 question1 () {
   touch /opt/appdata/plexguide/rclone.conf
   transport=$(cat /var/plexguide/pgclone.transport)
+  defaultFolders=$(cat /var/plexguide/pgclone.defaultFolders)
   gstatus=$(cat /var/plexguide/gdrive.pgclone)
   tstatus=$(cat /var/plexguide/tdrive.pgclone)
   transportdisplay
@@ -151,11 +193,12 @@ tee <<-EOF
 💪 Welcome to PG Clone                 📓 Reference: pgclone.plexguide.com
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-[1] Data Transport Mode: $transport
+[1] Data Transport Mode:  $transport
 [2] OAuth & Mounts
-[3] Key Management:      $keynum Keys Deployed
-[4] Throttle Limit:      $bwdisplay2 MB
-[5] Deploy:              $transport
+[3] Key Management:       $keynum Keys Deployed
+[4] Throttle Limit:       $bwdisplay2 MB
+[5] Make Default Folders: $defaultFolders
+[6] Deploy:               $transport
 [Z] Exit
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -175,6 +218,9 @@ elif [ "$typed" == "4" ]; then
 bandwidthblitz
 question1
 elif [ "$typed" == "5" ]; then
+createDefaultFolders
+question1
+elif [ "$typed" == "6" ]; then
     if [ "$transport" == "PG Blitz /w No Encryption" ]; then
       removepgservices
       deploygdrivecheck
@@ -214,10 +260,11 @@ tee <<-EOF
 💪 Welcome to PG Clone                 📓 Reference: pgclone.plexguide.com
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-[1] Data Transport Mode: $transport
+[1] Data Transport Mode:  $transport
 [2] OAuth & Mounts
-[3] Throttle Limit:      $bwdisplay MB
-[4] Deploy:              $transport
+[3] Throttle Limit:       $bwdisplay MB
+[4] Make Default Folders: $defaultFolders
+[5] Deploy:               $transport
 [Z] Exit
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -234,6 +281,9 @@ elif [ "$typed" == "3" ]; then
 bandwidth
 question1
 elif [ "$typed" == "4" ]; then
+createDefaultFolders
+question1
+elif [ "$typed" == "5" ]; then
     if [ "$transport" == "PG Move /w No Encryption" ]; then
       mkdir -p /var/plexguide/rclone/
       echo "gdrive" > /var/plexguide/rclone/deploy.version
@@ -271,6 +321,7 @@ variable /var/plexguide/pgclone.public ""
 variable /var/plexguide/pgclone.secret ""
 variable /var/plexguide/rclone/deploy.version "null"
 variable /var/plexguide/pgclone.transport "PG Move /w No Encryption"
+variable /var/plexguide/pgclone.defaultFolders "Yes"
 variable /var/plexguide/gdrive.pgclone "⚠️  Not Activated"
 variable /var/plexguide/tdrive.pgclone "⚠️  Not Activated"
 variable /var/plexguide/move.bw  "9"

--- a/gdrive.yml
+++ b/gdrive.yml
@@ -9,6 +9,10 @@
 - hosts: localhost
   gather_facts: false
   tasks:
+    - name: Read Default Folder Choice
+      shell: "cat /var/plexguide/pgclone.defaultFolders"
+      register: defaultFolderChoice
+      
     - name: Install GDRIVE Service
       template:
         src: /opt/pgclone/templates/gdrive.service
@@ -23,10 +27,15 @@
         state: reloaded
         name: gdrive
 
-    - name: Create GDRIVE Folders
+    - name: Create GDRIVE Folder
       file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
       with_items:
         - /mnt/gdrive
+        
+    - name: Create GDRIVE Default Folders
+      when: defaultFolderChoice.stdout.find('Yes') != -1
+      file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
+      with_items:
         - /mnt/gdrive/tv
         - /mnt/gdrive/movies
         - /mnt/gdrive/music

--- a/tcrypt.yml
+++ b/tcrypt.yml
@@ -9,6 +9,10 @@
 - hosts: localhost
   gather_facts: false
   tasks:
+    - name: Read Default Folder Choice
+      shell: "cat /var/plexguide/pgclone.defaultFolders"
+      register: defaultFolderChoice
+      
     - name: Install TCrypt Service
       template:
         src: /opt/pgclone/templates/tcrypt.service
@@ -23,10 +27,15 @@
         name: tcrypt
 
 
-    - name: Create TCrypt Folders
+    - name: Create TCrypt Folder
       file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
       with_items:
         - /mnt/tcrypt
+        
+    - name: Create TCrypt Default Folders
+      when: defaultFolderChoice.stdout.find('Yes') != -1
+      file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
+      with_items:
         - /mnt/tcrypt/tv
         - /mnt/tcrypt/movies
         - /mnt/tcrypt/music

--- a/tdrive.yml
+++ b/tdrive.yml
@@ -9,6 +9,10 @@
 - hosts: localhost
   gather_facts: false
   tasks:
+    - name: Read Default Folder Choice
+      shell: "cat /var/plexguide/pgclone.defaultFolders"
+      register: defaultFolderChoice
+    
     - name: Install TDRIVE Service
       template:
         src: /opt/pgclone/templates/tdrive.service
@@ -23,10 +27,15 @@
         state: reloaded
         name: tdrive
 
-    - name: Create TDrive Folders
+    - name: Create TDrive Folder
       file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
       with_items:
         - /mnt/tdrive
+        
+    - name: Create TDrive Default Folders
+      when: defaultFolderChoice.stdout.find('Yes') != -1
+      file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
+      with_items:
         - /mnt/tdrive/tv
         - /mnt/tdrive/movies
         - /mnt/tdrive/music


### PR DESCRIPTION
I've seen a few sparse comments on the forums and whatnot where some are annoyed that the default media folders (abooks, ebooks, movies, music, tv) keep getting created when they get deleted (eg: if people are using their own file structure).

This change adds an option to pgclone that, should the user wish, will allow them to set an option so those folders are not created by default. 

The default option is set to Yes, create folders. And I've added a warning in there for those who are unsure. See https://github.com/Haulien/PlexGuide-PGClone/blob/a40b04500ec6fdb140d12dccdbab0e882ab3bd35/gdrive.sh#L49 for the warning and the function. 

It auto-sets /var/plexguide/pgclone.defaultFolders which is then read by the ansible playbooks for gdrive, gcrypt, tdrive and tcrypt. If set to Yes (default) it proceeds as normal. If set to No by the user then just the main directory (/mnt/tcrypt, etc) is created.